### PR TITLE
CEDS-1812-disassociate-mucr

### DIFF
--- a/app/uk/gov/hmrc/exports/movements/models/consolidation/Consolidation.scala
+++ b/app/uk/gov/hmrc/exports/movements/models/consolidation/Consolidation.scala
@@ -23,30 +23,38 @@ import uk.gov.hmrc.play.json.Union
 object ConsolidationType extends Enumeration {
   type ConsolidationType = Value
 
-  val ASSOCIATE_DUCR, DISASSOCIATE_DUCR, SHUT_MUCR = Value
+  val ASSOCIATE_DUCR, DISASSOCIATE_DUCR, ASSOCIATE_MUCR, DISASSOCIATE_MUCR, SHUT_MUCR = Value
 
   implicit val format: Format[consolidation.ConsolidationType.Value] = Format(Reads.enumNameReads(ConsolidationType), Writes.enumNameWrites)
 }
 
 import uk.gov.hmrc.exports.movements.models.consolidation.ConsolidationType._
 
-sealed abstract class Consolidation(val consolidationType: ConsolidationType, val mucrOpt: Option[String], val ducrOpt: Option[String])
+sealed abstract class Consolidation(val consolidationType: ConsolidationType, val mucrOpt: Option[String], val ucrOpt: Option[String])
 
-case class AssociateDucrRequest(mucr: String, ducr: String) extends Consolidation(ASSOCIATE_DUCR, Some(mucr), Some(ducr))
+case class AssociateDucrRequest(mucr: String, ucr: String) extends Consolidation(ASSOCIATE_DUCR, Some(mucr), Some(ucr))
 
-case class DisassiociateDucrRequest(ducr: String) extends Consolidation(DISASSOCIATE_DUCR, None, Some(ducr))
+case class DisassociateDucrRequest(ucr: String) extends Consolidation(DISASSOCIATE_DUCR, None, Some(ucr))
+
+case class AssociateMucrRequest(mucr: String, ucr: String) extends Consolidation(ASSOCIATE_MUCR, Some(mucr), Some(ucr))
+
+case class DisassociateMucrRequest(ucr: String) extends Consolidation(DISASSOCIATE_MUCR, None, Some(ucr))
 
 case class ShutMucrRequest(mucr: String) extends Consolidation(SHUT_MUCR, Some(mucr), None)
 
 object Consolidation {
   implicit val associateDucrFormat = Json.format[AssociateDucrRequest]
-  implicit val disassiociateDucrFormat = Json.format[DisassiociateDucrRequest]
+  implicit val disassociateDucrFormat = Json.format[DisassociateDucrRequest]
+  implicit val associateMucrFormat = Json.format[AssociateMucrRequest]
+  implicit val disassociateMucrFormat = Json.format[DisassociateMucrRequest]
   implicit val shutMucrFormat = Json.format[ShutMucrRequest]
 
   implicit val format = Union
     .from[Consolidation](typeField = "consolidationType")
     .and[AssociateDucrRequest](typeTag = ASSOCIATE_DUCR.toString)
-    .and[DisassiociateDucrRequest](typeTag = DISASSOCIATE_DUCR.toString)
+    .and[DisassociateDucrRequest](typeTag = DISASSOCIATE_DUCR.toString)
+    .and[AssociateMucrRequest](typeTag = ASSOCIATE_MUCR.toString)
+    .and[DisassociateMucrRequest](typeTag = DISASSOCIATE_MUCR.toString)
     .and[ShutMucrRequest](typeTag = SHUT_MUCR.toString)
     .format
 }

--- a/app/uk/gov/hmrc/exports/movements/models/submissions/ActionType.scala
+++ b/app/uk/gov/hmrc/exports/movements/models/submissions/ActionType.scala
@@ -29,6 +29,8 @@ object ActionType {
   case object Departure extends ActionType("Departure")
   case object DucrAssociation extends ActionType("DucrAssociation")
   case object DucrDisassociation extends ActionType("DucrDisassociation")
+  case object MucrAssociation extends ActionType("MucrAssociation")
+  case object MucrDisassociation extends ActionType("MucrDisassociation")
   case object ShutMucr extends ActionType("ShutMucr")
 
   implicit val format = new Format[ActionType] {
@@ -39,6 +41,8 @@ object ActionType {
       case JsString("Departure")          => JsSuccess(Departure)
       case JsString("DucrAssociation")    => JsSuccess(DucrAssociation)
       case JsString("DucrDisassociation") => JsSuccess(DucrDisassociation)
+      case JsString("MucrAssociation")    => JsSuccess(MucrAssociation)
+      case JsString("MucrDisassociation") => JsSuccess(MucrDisassociation)
       case JsString("ShutMucr")           => JsSuccess(ShutMucr)
       case _                              => JsError("Unknown ActionType")
     }
@@ -47,6 +51,8 @@ object ActionType {
   def apply(consolidationType: ConsolidationType): ActionType = consolidationType match {
     case ASSOCIATE_DUCR    => DucrAssociation
     case DISASSOCIATE_DUCR => DucrDisassociation
+    case ASSOCIATE_MUCR    => MucrAssociation
+    case DISASSOCIATE_MUCR => MucrDisassociation
     case SHUT_MUCR         => ShutMucr
     case _                 => throw new IllegalArgumentException("Incorrect consolidation type")
   }

--- a/app/uk/gov/hmrc/exports/movements/services/ILEMapper.scala
+++ b/app/uk/gov/hmrc/exports/movements/services/ILEMapper.scala
@@ -18,8 +18,7 @@ package uk.gov.hmrc.exports.movements.services
 
 import javax.inject.Singleton
 import uk.gov.hmrc.exports.movements.models.consolidation.Consolidation
-import uk.gov.hmrc.exports.movements.models.consolidation.ConsolidationType.ConsolidationType
-import uk.gov.hmrc.exports.movements.models.consolidation.ConsolidationType._
+import uk.gov.hmrc.exports.movements.models.consolidation.ConsolidationType.{ConsolidationType, _}
 
 import scala.xml.{Node, NodeSeq}
 
@@ -31,7 +30,7 @@ class ILEMapper {
       <inventoryLinkingConsolidationRequest xmlns="http://gov.uk/customs/inventoryLinking/v1">
         <messageCode>{buildMessageCode(consolidation.consolidationType)}</messageCode>
         {buildMasterUcrNode(consolidation.mucrOpt)}
-        {buildUcrBlockNode(consolidation.ducrOpt)}
+        {buildUcrBlockNode(consolidation.consolidationType, consolidation.ucrOpt)}
       </inventoryLinkingConsolidationRequest>
     }
 
@@ -43,11 +42,16 @@ class ILEMapper {
   private def buildMasterUcrNode(mucrOpt: Option[String]): NodeSeq =
     mucrOpt.map(mucr => <masterUCR>{mucr}</masterUCR>).getOrElse(NodeSeq.Empty)
 
-  private def buildUcrBlockNode(ducrOpt: Option[String]): NodeSeq =
-    ducrOpt.map { ducr =>
+  private def buildUcrBlockNode(consolidationType: ConsolidationType, ucrOpt: Option[String]): NodeSeq =
+    ucrOpt.map { ducr =>
       <ucrBlock>
         <ucr>{ducr}</ucr>
-        <ucrType>D</ucrType>
+        <ucrType>{ucrType(consolidationType)}</ucrType>
       </ucrBlock>
     }.getOrElse(NodeSeq.Empty)
+
+  private def ucrType(consolidationType: ConsolidationType): String = consolidationType match {
+    case ASSOCIATE_DUCR | DISASSOCIATE_DUCR => "D"
+    case ASSOCIATE_MUCR | DISASSOCIATE_MUCR => "M"
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ import uk.gov.hmrc.{SbtArtifactory, SbtAutoBuildPlugin}
 
 val appName = "customs-declare-exports-movements"
 
+PlayKeys.devSettings := Seq("play.server.http.port" -> "6797")
 
 lazy val allResolvers = resolvers ++= Seq(
   Resolver.bintrayRepo("hmrc", "releases"),

--- a/test/unit/uk/gov/hmrc/exports/movements/models/SubmissionFactorySpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/movements/models/SubmissionFactorySpec.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.exports.movements.models.consolidation.ConsolidationType._
 import uk.gov.hmrc.exports.movements.models.movements.{ConsignmentReference, MovementDetails}
 import uk.gov.hmrc.exports.movements.models.notifications.UcrBlock
 import uk.gov.hmrc.exports.movements.models.submissions.{ActionType, Submission, SubmissionFactory}
-import utils.testdata.CommonTestData._
+import utils.testdata.CommonTestData.{conversationId, _}
 import utils.testdata.ConsolidationTestData._
 import utils.testdata.MovementsTestData.{exampleArrivalRequestXML, exampleDepartureRequestXML}
 
@@ -70,7 +70,7 @@ class SubmissionFactorySpec extends WordSpec with MustMatchers with MockitoSugar
         compareSubmissions(submission, expectedSubmission)
       }
 
-      "provided with Association request" in new Test {
+      "provided with Association Ducr request" in new Test {
 
         val submission =
           submissionFactory.buildConsolidationSubmission(validEori, conversationId, exampleAssociateDucrConsolidationRequestXML, ASSOCIATE_DUCR)
@@ -85,7 +85,22 @@ class SubmissionFactorySpec extends WordSpec with MustMatchers with MockitoSugar
         compareSubmissions(submission, expectedSubmission)
       }
 
-      "provided with Disassociation request" in new Test {
+      "provided with Association Mucr request" in new Test {
+
+        val submission =
+          submissionFactory.buildConsolidationSubmission(validEori, conversationId, exampleAssociateMucrConsolidationRequestXML, ASSOCIATE_MUCR)
+
+        val expectedSubmission = Submission(
+          eori = validEori,
+          conversationId = conversationId,
+          actionType = ActionType.MucrAssociation,
+          ucrBlocks = Seq(UcrBlock(ucr = ucr_2, ucrType = "M"), UcrBlock(ucr = ucr, ucrType = "M"))
+        )
+
+        compareSubmissions(submission, expectedSubmission)
+      }
+
+      "provided with Disassociation Ducr request" in new Test {
 
         val submission =
           submissionFactory.buildConsolidationSubmission(validEori, conversationId, exampleDisassociateDucrConsolidationRequestXML, DISASSOCIATE_DUCR)
@@ -95,6 +110,21 @@ class SubmissionFactorySpec extends WordSpec with MustMatchers with MockitoSugar
           conversationId = conversationId,
           actionType = ActionType.DucrDisassociation,
           ucrBlocks = Seq(UcrBlock(ucr = ucr, ucrType = "D"))
+        )
+
+        compareSubmissions(submission, expectedSubmission)
+      }
+
+      "provided with Disassociation Mucr request" in new Test {
+
+        val submission =
+          submissionFactory.buildConsolidationSubmission(validEori, conversationId, exampleDisassociateMucrConsolidationRequestXML, DISASSOCIATE_MUCR)
+
+        val expectedSubmission = Submission(
+          eori = validEori,
+          conversationId = conversationId,
+          actionType = ActionType.MucrDisassociation,
+          ucrBlocks = Seq(UcrBlock(ucr = ucr, ucrType = "M"))
         )
 
         compareSubmissions(submission, expectedSubmission)

--- a/test/unit/uk/gov/hmrc/exports/movements/models/consolidation/ConsolidationSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/movements/models/consolidation/ConsolidationSpec.scala
@@ -31,21 +31,41 @@ class ConsolidationSpec extends UnitSpec {
     "correct read Associate Ducr request" in {
 
       val associateDucrJson: JsValue =
-        JsObject(Map("consolidationType" -> JsString(ASSOCIATE_DUCR.toString), "mucr" -> JsString(mucr), "ducr" -> JsString(ducr)))
+        JsObject(Map("consolidationType" -> JsString(ASSOCIATE_DUCR.toString), "mucr" -> JsString(mucr), "ucr" -> JsString(ducr)))
 
       val expectedResult = AssociateDucrRequest(mucr, ducr)
 
       Consolidation.format.reads(associateDucrJson) shouldBe JsSuccess(expectedResult)
     }
 
+    "correct read Associate Mucr request" in {
+
+      val associateMucrJson: JsValue =
+        JsObject(Map("consolidationType" -> JsString(ASSOCIATE_MUCR.toString), "mucr" -> JsString(mucr), "ucr" -> JsString(mucr)))
+
+      val expectedResult = AssociateMucrRequest(mucr, mucr)
+
+      Consolidation.format.reads(associateMucrJson) shouldBe JsSuccess(expectedResult)
+    }
+
     "correct read Disassociate Ducr request" in {
 
       val diassociateDucrJson: JsValue =
-        JsObject(Map("consolidationType" -> JsString(DISASSOCIATE_DUCR.toString), "ducr" -> JsString(ducr)))
+        JsObject(Map("consolidationType" -> JsString(DISASSOCIATE_DUCR.toString), "ucr" -> JsString(ducr)))
 
-      val expectedResult = DisassiociateDucrRequest(ducr)
+      val expectedResult = DisassociateDucrRequest(ducr)
 
       Consolidation.format.reads(diassociateDucrJson) shouldBe JsSuccess(expectedResult)
+    }
+
+    "correct read Disassociate Mucr request" in {
+
+      val diassociateMucrJson: JsValue =
+        JsObject(Map("consolidationType" -> JsString(DISASSOCIATE_MUCR.toString), "ucr" -> JsString(mucr)))
+
+      val expectedResult = DisassociateMucrRequest(mucr)
+
+      Consolidation.format.reads(diassociateMucrJson) shouldBe JsSuccess(expectedResult)
     }
 
     "correct read Shut Mucr request" in {

--- a/test/utils/testdata/ConsolidationTestData.scala
+++ b/test/utils/testdata/ConsolidationTestData.scala
@@ -20,7 +20,7 @@ import play.api.http.{ContentTypes, HeaderNames}
 import play.api.libs.json.{JsObject, JsString, JsValue}
 import play.api.mvc.Codec
 import uk.gov.hmrc.exports.movements.controllers.util.CustomsHeaderNames
-import uk.gov.hmrc.exports.movements.models.consolidation.{AssociateDucrRequest, DisassiociateDucrRequest, ShutMucrRequest}
+import uk.gov.hmrc.exports.movements.models.consolidation.{AssociateDucrRequest, DisassociateDucrRequest, ShutMucrRequest}
 import utils.testdata.CommonTestData._
 
 import scala.xml.{Elem, Node}
@@ -28,7 +28,7 @@ import scala.xml.{Elem, Node}
 object ConsolidationTestData {
 
   val associateDucrRequest = AssociateDucrRequest(ucr, ucr_2)
-  val disassiociateDucrRequest = DisassiociateDucrRequest(ucr_2)
+  val disassiociateDucrRequest = DisassociateDucrRequest(ucr_2)
   val shutMucrRequest = ShutMucrRequest(ucr)
 
   val exampleShutMucrConsolidationRequestXML: Node =
@@ -47,12 +47,31 @@ object ConsolidationTestData {
       </ucrBlock>
     </inventoryLinkingConsolidationRequest>
 
+  val exampleAssociateMucrConsolidationRequestXML: Elem =
+    <inventoryLinkingConsolidationRequest>
+      <messageCode>{MessageCodes.EAC}</messageCode>
+      <masterUCR>{ucr_2}</masterUCR>
+      <ucrBlock>
+        <ucr>{ucr}</ucr>
+        <ucrType>M</ucrType>
+      </ucrBlock>
+    </inventoryLinkingConsolidationRequest>
+
   val exampleDisassociateDucrConsolidationRequestXML: Elem =
     <inventoryLinkingConsolidationRequest>
       <messageCode>{MessageCodes.EAC}</messageCode>
       <ucrBlock>
         <ucr>{ucr}</ucr>
         <ucrType>D</ucrType>
+      </ucrBlock>
+    </inventoryLinkingConsolidationRequest>
+
+  val exampleDisassociateMucrConsolidationRequestXML: Elem =
+    <inventoryLinkingConsolidationRequest>
+      <messageCode>{MessageCodes.EAC}</messageCode>
+      <ucrBlock>
+        <ucr>{ucr}</ucr>
+        <ucrType>M</ucrType>
       </ucrBlock>
     </inventoryLinkingConsolidationRequest>
 


### PR DESCRIPTION
This PR is to extend the 'Consolidation' message to handle two new MUCR-MUCR types so that CEDS-1595 and CEDS-1812 can be worked on in parallel.

