### PR TITLE
CEDS-1858 Fix for missing User Agent in HeaderCarrier

### DIFF
--- a/app/uk/gov/hmrc/exports/movements/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/exports/movements/config/AppConfig.scala
@@ -37,7 +37,7 @@ class AppConfig @Inject()(runModeConfiguration: Configuration, servicesConfig: S
 
   def clientIdInventory(implicit hc: HeaderCarrier): String = {
     val userAgent = hc.headers.find(_._1.toLowerCase() == "user-agent").map(_._2).getOrElse {
-      Logger.warn("Request had missing User-Agent header. Falling Back to a default Client ID")
+      logger.warn("Request had missing User-Agent header. Falling Back to a default Client ID")
       "default"
     }
     servicesConfig.getConfString(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -167,3 +167,5 @@ microservice {
         }
     }
 }
+
+httpHeadersWhitelist = ["User-Agent"]


### PR DESCRIPTION
HeaderCarrier wasn't picking up the User-Agent which is required for client ID switching. Looks like it can be configured in application.conf