### PR TITLE
CEDS-1869 Add internal UI clientID to the config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -163,6 +163,7 @@ microservice {
             client-id {
                 default = "5c68d3b5-d8a7-4212-8688-6b67f18bbce7"
                 customs-movements-frontend = "5c68d3b5-d8a7-4212-8688-6b67f18bbce7"
+                customs-exports-internal-frontend = "5c68d3b5-d8a7-4212-8688-6b67f18bbce7"
             }
             schema-file-path = "conf/schemas/exports/inventoryLinkingResponseExternal.xsd"
         }


### PR DESCRIPTION
The value is the same as for movements frontend service, as it will be
used for locally running application only. It is overridden on every
environment with appropriate value.