### PR TITLE
CEDS-1863 Ensure Missing Client ID leads to a 401

### DIFF
--- a/app/uk/gov/hmrc/exports/movements/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/exports/movements/config/AppConfig.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.exports.movements.config
 
 import com.google.inject.{Inject, Singleton}
 import play.api.{Configuration, Logger}
+import uk.gov.hmrc.exports.movements.exceptions.MissingClientIDException
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -40,10 +41,7 @@ class AppConfig @Inject()(runModeConfiguration: Configuration, servicesConfig: S
       logger.warn("Request had missing User-Agent header. Falling Back to a default Client ID")
       "default"
     }
-    servicesConfig.getConfString(
-      s"customs-inventory-linking-exports.client-id.$userAgent",
-      throw new IllegalStateException(s"Missing Client ID for [$userAgent]")
-    )
+    servicesConfig.getConfString(s"customs-inventory-linking-exports.client-id.$userAgent", throw MissingClientIDException(userAgent))
   }
 
   lazy val ileSchemasFilePath = servicesConfig.getConfString(

--- a/app/uk/gov/hmrc/exports/movements/exceptions/MissingClientIDException.scala
+++ b/app/uk/gov/hmrc/exports/movements/exceptions/MissingClientIDException.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.movements.exceptions
+
+import uk.gov.hmrc.auth.core.AuthorisationException
+
+case class MissingClientIDException(serviceName: String) extends AuthorisationException(s"Missing Client ID for [$serviceName]")


### PR DESCRIPTION
The default error handler converts AuthorizationExceptions to 401s

At the moment the back end returns 500s