### PR TITLE
CEDS-2043 Fix parse exception for Frustrated Exports

### DIFF
--- a/app/uk/gov/hmrc/exports/movements/models/movements/Transport.scala
+++ b/app/uk/gov/hmrc/exports/movements/models/movements/Transport.scala
@@ -15,9 +15,10 @@
  */
 
 package uk.gov.hmrc.exports.movements.models.movements
+
 import play.api.libs.json.{Json, OFormat}
 
-case class Transport(modeOfTransport: String, nationality: String, transportId: String)
+case class Transport(modeOfTransport: Option[String], nationality: Option[String], transportId: Option[String])
 
 object Transport {
   implicit val format: OFormat[Transport] = Json.format[Transport]

--- a/app/uk/gov/hmrc/exports/movements/services/ILEMapper.scala
+++ b/app/uk/gov/hmrc/exports/movements/services/ILEMapper.scala
@@ -18,14 +18,7 @@ package uk.gov.hmrc.exports.movements.services
 
 import javax.inject.Singleton
 import uk.gov.hmrc.exports.movements.models.consolidation.Consolidation
-import uk.gov.hmrc.exports.movements.models.consolidation.ConsolidationType.{
-  ASSOCIATE_DUCR,
-  ASSOCIATE_MUCR,
-  ConsolidationType,
-  DISASSOCIATE_DUCR,
-  DISASSOCIATE_MUCR,
-  SHUT_MUCR
-}
+import uk.gov.hmrc.exports.movements.models.consolidation.ConsolidationType._
 import uk.gov.hmrc.exports.movements.models.movements.Choice.{Arrival, Departure}
 import uk.gov.hmrc.exports.movements.models.movements.{Movement, MovementDetails, Transport}
 import uk.gov.hmrc.wco.dec.inventorylinking.common.{TransportDetails, UcrBlock}
@@ -64,12 +57,7 @@ class ILEMapper {
 
   private def mapTransportDetails(transport: Option[Transport]): Option[TransportDetails] =
     transport.map(
-      data =>
-        TransportDetails(
-          transportID = Some(data.transportId),
-          transportMode = Some(data.modeOfTransport),
-          transportNationality = Some(data.nationality)
-      )
+      data => TransportDetails(transportID = data.transportId, transportMode = data.modeOfTransport, transportNationality = data.nationality)
     )
 
   def generateConsolidationXml(consolidation: Consolidation): Node =

--- a/test/utils/testdata/MovementsTestData.scala
+++ b/test/utils/testdata/MovementsTestData.scala
@@ -42,11 +42,6 @@ object MovementsTestData {
         <goodsLocation>GBAUlocation</goodsLocation>
         <goodsArrivalDateTime>2019-07-12T13:14:54.000Z</goodsArrivalDateTime>
         <movementReference>{movementReference}</movementReference>
-        <transportDetails>
-          <transportID>{transportId}</transportID>
-          <transportMode>{transportMode}</transportMode>
-          <transportNationality>{transportNationality}</transportNationality>
-        </transportDetails>
       </inventoryLinkingMovementRequest>
     }
 
@@ -58,7 +53,7 @@ object MovementsTestData {
     movementDetails = MovementDetails("2019-07-12T13:14:54.000Z"),
     location = Some(Location("GBAUlocation")),
     arrivalReference = Some(ArrivalReference(Some(movementReference))),
-    transport = Some(Transport(transportMode, transportNationality, transportId))
+    transport = None
   )
 
   val exampleArrivalRequestJson: JsValue = Json.toJson(exampleArrivalRequest)
@@ -73,7 +68,6 @@ object MovementsTestData {
       </ucrBlock>
       <goodsLocation>GBAUlocation</goodsLocation>
       <goodsDepartureDateTime>2019-07-12T13:14:54.000Z</goodsDepartureDateTime>
-      <movementReference>{movementReference}</movementReference>
       <transportDetails>
         <transportID>{transportId}</transportID>
         <transportMode>{transportMode}</transportMode>
@@ -89,21 +83,10 @@ object MovementsTestData {
     consignmentReference = ConsignmentReference("D", "7GB123456789000-123ABC456DEFQWERT"),
     movementDetails = MovementDetails("2019-07-12T13:14:54.000Z"),
     location = Some(Location("GBAUlocation")),
-    arrivalReference = Some(ArrivalReference(Some(movementReference))),
-    transport = Some(Transport(transportMode, transportNationality, transportId))
+    transport = Some(Transport(Some(transportMode), Some(transportNationality), Some(transportId)))
   )
 
-  val exampleDepartureRequestJson: JsValue = Json.toJson(
-    Movement(
-      eori = validEori,
-      choice = "EDL",
-      consignmentReference = ConsignmentReference("D", "7GB123456789000-123ABC456DEFQWERT"),
-      movementDetails = MovementDetails("2019-07-12T13:14:54.000Z"),
-      location = Some(Location("GBAUlocation")),
-      arrivalReference = Some(ArrivalReference(Some(movementReference))),
-      transport = Some(Transport(transportMode, transportNationality, transportId))
-    )
-  )
+  val exampleDepartureRequestJson: JsValue = Json.toJson(exampleDepartureRequest)
 
   def exampleSubmission(
     eori: String = validEori,


### PR DESCRIPTION
The problem was a consequence of discrepancy in models between Backend
and Frontend services. Backend did expect all elements in Transport to
be present. This was not a problem as all 3 elements were mandatory for
'Out of the UK' exports. Introduction of 'Back into the UK' allowed not
all elements to be present and so the Backend parser was looking for
values that were not present in the JSON.