### PR TITLE
CEDS-1903 Use Instant as caring class for date and time in movement request.

### DIFF
--- a/app/uk/gov/hmrc/exports/movements/models/movements/MovementDetails.scala
+++ b/app/uk/gov/hmrc/exports/movements/models/movements/MovementDetails.scala
@@ -15,9 +15,11 @@
  */
 
 package uk.gov.hmrc.exports.movements.models.movements
+import java.time.Instant
+
 import play.api.libs.json.{Json, OFormat}
 
-case class MovementDetails(dateTime: String)
+case class MovementDetails(dateTime: Instant)
 
 object MovementDetails {
   implicit val format: OFormat[MovementDetails] = Json.format[MovementDetails]

--- a/app/uk/gov/hmrc/exports/movements/services/ILEMapper.scala
+++ b/app/uk/gov/hmrc/exports/movements/services/ILEMapper.scala
@@ -41,12 +41,12 @@ class ILEMapper @Inject()(clock: Clock) {
   private def generateInventoryLinkingMovementRequest(request: Movement): InventoryLinkingMovementRequest = {
 
     val departureDetails: Option[String] = request.choice match {
-      case Departure => request.movementDetails.map(movement => formatOutputDateTime(parseDateTime(movement.dateTime)))
+      case Departure => request.movementDetails.map(movement => formatOutputDateTime(movement.dateTime))
       case _         => None
     }
 
     val arrivalDetails: Option[String] = request.choice match {
-      case Arrival              => request.movementDetails.map(movement => formatOutputDateTime(parseDateTime(movement.dateTime)))
+      case Arrival              => request.movementDetails.map(movement => formatOutputDateTime(movement.dateTime))
       case RetrospectiveArrival => Some(formatOutputDateTime(Instant.now(clock)))
       case _                    => None
     }
@@ -62,8 +62,6 @@ class ILEMapper @Inject()(clock: Clock) {
       movementReference = request.arrivalReference.flatMap(_.reference)
     )
   }
-
-  private def parseDateTime(dateTime: String): Instant = Instant.from(dateTimeFormatter.parse(dateTime))
 
   private def formatOutputDateTime(dateTime: Instant): String = dateTimeFormatter.format(dateTime.truncatedTo(ChronoUnit.SECONDS))
 

--- a/test/component/uk/gov/hmrc/exports/movements/RetrospectiveArrivalSpec.scala
+++ b/test/component/uk/gov/hmrc/exports/movements/RetrospectiveArrivalSpec.scala
@@ -42,7 +42,6 @@ class RetrospectiveArrivalSpec extends ComponentSpec {
           "choice" -> "RET",
           "consignmentReference" -> Json.obj("reference" -> "M", "referenceValue" -> "UCR"),
           "location" -> Json.obj("code" -> "abc"),
-          "movementDetails" -> Json.obj("dateTime" -> "some date time"),
           "arrivalReference" -> Json.obj("reference" -> "xyz"),
           "transport" -> Json.obj("modeOfTransport" -> "mode", "nationality" -> "nationality", "transportId" -> "transportId")
         )

--- a/test/integration/uk/gov/hmrc/exports/movements/connector/ConnectorSpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/movements/connector/ConnectorSpec.scala
@@ -27,13 +27,13 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
-import utils.testdata.MovementsTestData.dateTimeString
+import utils.testdata.MovementsTestData.dateTime
 
 import scala.concurrent.ExecutionContext
 
 class ConnectorSpec extends WordSpec with GuiceOneAppPerSuite with WiremockTestServer with MustMatchers with MockitoSugar with BeforeAndAfterEach {
 
-  private val clock = Clock.fixed(Instant.parse(dateTimeString), ZoneOffset.UTC)
+  private val clock = Clock.fixed(dateTime, ZoneOffset.UTC)
 
   override def fakeApplication(): Application = {
     SharedMetricRegistries.clear()

--- a/test/integration/uk/gov/hmrc/exports/movements/repositories/NotificationRepositorySpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/movements/repositories/NotificationRepositorySpec.scala
@@ -27,7 +27,7 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.exports.movements.repositories.NotificationRepository
 import utils.testdata.CommonTestData.{conversationId, conversationId_2}
-import utils.testdata.MovementsTestData.dateTimeString
+import utils.testdata.MovementsTestData.dateTime
 import utils.testdata.notifications.NotificationTestData._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -35,7 +35,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class NotificationRepositorySpec
     extends WordSpec with GuiceOneAppPerSuite with BeforeAndAfterEach with ScalaFutures with MustMatchers with IntegrationPatience {
 
-  private val clock = Clock.fixed(Instant.parse(dateTimeString), ZoneOffset.UTC)
+  private val clock = Clock.fixed(dateTime, ZoneOffset.UTC)
 
   override def fakeApplication: Application = {
     SharedMetricRegistries.clear()

--- a/test/integration/uk/gov/hmrc/exports/movements/repositories/SubmissionRepositorySpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/movements/repositories/SubmissionRepositorySpec.scala
@@ -37,7 +37,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class SubmissionRepositorySpec
     extends WordSpec with GuiceOneAppPerSuite with BeforeAndAfterEach with ScalaFutures with MustMatchers with IntegrationPatience {
 
-  private val clock = Clock.fixed(Instant.parse(dateTimeString), ZoneOffset.UTC)
+  private val clock = Clock.fixed(dateTime, ZoneOffset.UTC)
 
   override def fakeApplication: Application = {
     SharedMetricRegistries.clear()

--- a/test/integration/uk/gov/hmrc/exports/movements/services/SubmissionServiceSpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/movements/services/SubmissionServiceSpec.scala
@@ -47,7 +47,7 @@ class SubmissionServiceSpec
     with IntegrationPatience {
 
   private val submissionRepository: SubmissionRepository = buildSubmissionRepositoryMock
-  private val clock = Clock.fixed(Instant.parse(dateTimeString), ZoneOffset.UTC)
+  private val clock = Clock.fixed(dateTime, ZoneOffset.UTC)
 
   def overrideModules: Seq[GuiceableModule] = Nil
 

--- a/test/unit/uk/gov/hmrc/exports/movements/controllers/MovementsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/movements/controllers/MovementsControllerSpec.scala
@@ -16,6 +16,8 @@
 
 package unit.uk.gov.hmrc.exports.movements.controllers
 
+import java.time.Instant
+
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
 import org.scalatest.BeforeAndAfterEach
@@ -44,7 +46,7 @@ class MovementsControllerSpec extends UnitSpec with MockitoSugar with BeforeAndA
     eori = validEori,
     choice = MovementType.Arrival,
     consignmentReference = ConsignmentReference("reference", "value"),
-    movementDetails = Some(MovementDetails("dateTime"))
+    movementDetails = Some(MovementDetails(Instant.now()))
   )
 
   override protected def beforeEach(): Unit =

--- a/test/unit/uk/gov/hmrc/exports/movements/controllers/NotificationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/movements/controllers/NotificationControllerSpec.scala
@@ -37,7 +37,7 @@ import uk.gov.hmrc.exports.movements.services.NotificationService
 import unit.uk.gov.hmrc.exports.movements.base.AuthTestSupport
 import unit.uk.gov.hmrc.exports.movements.base.UnitTestMockBuilder._
 import utils.testdata.CommonTestData.conversationId
-import utils.testdata.MovementsTestData.dateTimeString
+import utils.testdata.MovementsTestData.dateTime
 import utils.testdata.notifications.NotificationTestData._
 import utils.testdata.notifications.{ExampleInventoryLinkingControlResponse, ExampleInventoryLinkingMovementTotalsResponse}
 
@@ -51,7 +51,7 @@ class NotificationControllerSpec
 
   private val notificationServiceMock: NotificationService = buildNotificationServiceMock
   private val movementNotificationFactoryMock: NotificationFactory = buildMovementNotificationFactoryMock
-  private val clock = Clock.fixed(Instant.parse(dateTimeString), ZoneOffset.UTC)
+  private val clock = Clock.fixed(dateTime, ZoneOffset.UTC)
 
   override lazy val app: Application = GuiceApplicationBuilder()
     .overrides(

--- a/test/unit/uk/gov/hmrc/exports/movements/services/ILEMapperSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/movements/services/ILEMapperSpec.scala
@@ -27,7 +27,7 @@ import utils.testdata.MovementsTestData._
 
 class ILEMapperSpec extends UnitSpec {
 
-  private val clock = Clock.fixed(Instant.parse(dateTimeString), ZoneOffset.UTC)
+  private val clock = Clock.fixed(dateTime, ZoneOffset.UTC)
   private val ileMapper = new ILEMapper(clock)
 
   "ILE Mapper" should {
@@ -37,7 +37,7 @@ class ILEMapperSpec extends UnitSpec {
       val input = exampleArrivalRequest
       val expectedXml = exampleArrivalRequestXML
 
-      ileMapper.generateInventoryLinkingMovementRequestXml(input) shouldBe expectedXml
+      ileMapper.generateInventoryLinkingMovementRequestXml(input).toString should equal(expectedXml.toString)
     }
 
     "create correct XML for Retrospective Arrival" which {
@@ -48,7 +48,7 @@ class ILEMapperSpec extends UnitSpec {
 
         val xml = ileMapper.generateInventoryLinkingMovementRequestXml(input)
 
-        xml shouldBe expectedXml
+        xml.toString shouldEqual expectedXml.toString
       }
     }
 
@@ -57,7 +57,7 @@ class ILEMapperSpec extends UnitSpec {
       val input = exampleDepartureRequest
       val expectedXml = exampleDepartureRequestXML
 
-      ileMapper.generateInventoryLinkingMovementRequestXml(input) shouldBe expectedXml
+      ileMapper.generateInventoryLinkingMovementRequestXml(input).toString should equal(expectedXml.toString)
     }
 
     "create correct XML based on the consolidation" in {
@@ -65,7 +65,7 @@ class ILEMapperSpec extends UnitSpec {
       val consolidation = AssociateDucrRequest(eori = validEori, mucr = ucr_2, ucr = ucr)
       val expectedXml = scala.xml.Utility.trim(exampleAssociateDucrConsolidationRequestXML)
 
-      ileMapper.generateConsolidationXml(consolidation) shouldBe expectedXml
+      ileMapper.generateConsolidationXml(consolidation).toString shouldEqual expectedXml.toString
     }
   }
 }

--- a/test/utils/testdata/ConsolidationTestData.scala
+++ b/test/utils/testdata/ConsolidationTestData.scala
@@ -38,7 +38,7 @@ object ConsolidationTestData {
     </inventoryLinkingConsolidationRequest>
 
   val exampleAssociateDucrConsolidationRequestXML: Elem =
-    <inventoryLinkingConsolidationRequest>
+    <inventoryLinkingConsolidationRequest xmlns="http://gov.uk/customs/inventoryLinking/v1">
       <messageCode>{MessageCodes.EAC}</messageCode>
       <masterUCR>{ucr_2}</masterUCR>
       <ucrBlock>

--- a/test/utils/testdata/MovementsTestData.scala
+++ b/test/utils/testdata/MovementsTestData.scala
@@ -16,6 +16,8 @@
 
 package utils.testdata
 
+import java.time.Instant
+
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.exports.movements.models.movements.{Movement, _}
@@ -30,7 +32,7 @@ import scala.xml.Node
 object MovementsTestData {
 
   val now: DateTime = DateTime.now.withZone(DateTimeZone.UTC)
-  val dateTimeString: String = "2019-07-12T13:14:54Z"
+  val dateTime = Instant.parse("2019-07-12T13:14:54Z")
 
   val exampleArrivalRequestXML: Node =
     scala.xml.Utility.trim {
@@ -41,7 +43,7 @@ object MovementsTestData {
           <ucrType>D</ucrType>
         </ucrBlock>
         <goodsLocation>GBAUlocation</goodsLocation>
-        <goodsArrivalDateTime>{dateTimeString}</goodsArrivalDateTime>
+        <goodsArrivalDateTime>{dateTime}</goodsArrivalDateTime>
         <movementReference>{movementReference}</movementReference>
       </inventoryLinkingMovementRequest>
     }
@@ -51,7 +53,7 @@ object MovementsTestData {
     providerId = Some(validProviderId),
     choice = MovementType.Arrival,
     consignmentReference = ConsignmentReference("D", ucr),
-    movementDetails = Some(MovementDetails(dateTimeString)),
+    movementDetails = Some(MovementDetails(dateTime)),
     location = Some(Location("GBAUlocation")),
     arrivalReference = Some(ArrivalReference(Some(movementReference))),
     transport = None
@@ -68,7 +70,7 @@ object MovementsTestData {
           <ucrType>D</ucrType>
         </ucrBlock>
         <goodsLocation>GBAUlocation</goodsLocation>
-        <goodsArrivalDateTime>{dateTimeString}</goodsArrivalDateTime>
+        <goodsArrivalDateTime>{dateTime}</goodsArrivalDateTime>
       </inventoryLinkingMovementRequest>
     }
 
@@ -94,7 +96,7 @@ object MovementsTestData {
         <ucrType>D</ucrType>
       </ucrBlock>
       <goodsLocation>GBAUlocation</goodsLocation>
-      <goodsDepartureDateTime>{dateTimeString}</goodsDepartureDateTime>
+      <goodsDepartureDateTime>{dateTime}</goodsDepartureDateTime>
       <transportDetails>
         <transportID>{transportId}</transportID>
         <transportMode>{transportMode}</transportMode>
@@ -108,7 +110,7 @@ object MovementsTestData {
     providerId = Some(validProviderId),
     choice = MovementType.Departure,
     consignmentReference = ConsignmentReference("D", "7GB123456789000-123ABC456DEFQWERT"),
-    movementDetails = Some(MovementDetails(dateTimeString)),
+    movementDetails = Some(MovementDetails(dateTime)),
     location = Some(Location("GBAUlocation")),
     transport = Some(Transport(Some(transportMode), Some(transportNationality), Some(transportId)))
   )


### PR DESCRIPTION
We use here default ISO_INSTANT DateTimeFormatter - ISO 8601 with milisecond resolution.
Any problems with format are now reported as json validation errros.

We change to change comparison between XMLs because it does not recognize correctly
equality between two dates even if they are point same value after formatting.
After this tests were moved to compare result of `toString` on Nodes