### PR TITLE
CEDS-2170 Change GatewayTimeout to FailedDependency status for timeout

### DIFF
--- a/app/uk/gov/hmrc/exports/movements/controllers/IleQueryController.scala
+++ b/app/uk/gov/hmrc/exports/movements/controllers/IleQueryController.scala
@@ -37,10 +37,9 @@ class IleQueryController @Inject()(ileQueryService: IleQueryService, cc: Control
   def getIleQueryResponses(eori: Option[String], providerId: Option[String], conversationId: String): Action[AnyContent] = Action.async {
     implicit request =>
       val searchParameters = SearchParameters(eori = eori, providerId = providerId, conversationId = Some(conversationId))
-
       ileQueryService.fetchResponses(searchParameters).map {
         case Right(ileQueryResponses) => Ok(Json.toJson(ileQueryResponses))
-        case Left(_)                  => GatewayTimeout
+        case Left(timeoutError)       => FailedDependency(timeoutError.message)
       }
   }
 }

--- a/app/uk/gov/hmrc/exports/movements/services/IleQueryService.scala
+++ b/app/uk/gov/hmrc/exports/movements/services/IleQueryService.scala
@@ -74,9 +74,9 @@ class IleQueryService @Inject()(
         if (ileQueryTimeoutCalculator.hasQueryTimedOut(submission)) {
           logger
             .info(
-              s"Timeout occurred while waiting for ILE Query Response notification with conversation ID = [${searchParameters.conversationId.getOrElse("")}]"
+              s"Timeout occurred while waiting for ILE Query Response notification with Conversation ID = [${searchParameters.conversationId.getOrElse("")}]"
             )
-          Future.successful(Left(TimeoutError(s"This ILE Query is too old to get information about it")))
+          Future.successful(Left(TimeoutError("This ILE Query is too old to get information about it")))
         } else {
           getNotificationsConverted(Seq(submission.conversationId))
         }

--- a/test/unit/uk/gov/hmrc/exports/movements/controllers/IleQueryControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/movements/controllers/IleQueryControllerSpec.scala
@@ -126,14 +126,15 @@ class IleQueryControllerSpec extends WordSpec with MustMatchers with MockitoSuga
     }
 
     "IleQueryService returns Either.Left" should {
-      "return GatewayTimeout status" in {
+      "return FailedDependency (424) status with TimeoutError message from IleQueryService" in {
 
         when(ileQueryService.fetchResponses(any[SearchParameters])).thenReturn(Future.successful(Left(TimeoutError("TIMEOUT"))))
 
         val result = controller
           .getIleQueryResponses(eori = Some(validEori), providerId = Some(validProviderId), conversationId = conversationId)(getRequest())
 
-        status(result) mustBe GATEWAY_TIMEOUT
+        status(result) mustBe FAILED_DEPENDENCY
+        contentAsString(result) mustBe "TIMEOUT"
       }
     }
   }


### PR DESCRIPTION
There was a problem related to sending 5xx HTTP responses between our
services. Any 5xx code triggers Pager Duty Alert which is not the
behaviour we would like to have in this scenario.

Initially the idea was to create a new IleQueryResponseExchangeData
class for the purpose of indicating the timeout. However, this is
essentially a payload driven logic and it is better to drive logic by
HTTP codes.

424 Failed Dependency - seems to be the most appropriate in this
situation among all the codes available: "The request failed because it
depended on another request and that request failed"