### PR TITLE
CEDS-2897 update deprecated config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -70,12 +70,10 @@ play.crypto.secret="FYLCnHaiucpD9htbtF2HtYmbPNmwvk2WSTUbOKwuV8ZXUoOxqp5uERZl4uE7
 
 # Session configuration
 # ~~~~~
-play.http.session.httpOnly=false
 play.http.session.secure=false
 
 # The application languages
 # ~~~~~
-application.langs="en"
 
 # Router
 # ~~~~~


### PR DESCRIPTION
application.langs now deprecated, play.i18n.langs is provided with english language by default by the bootstrap libraries.

play.http.session.httpOnly shouldn't be required by backend services, and will be added to app-config-common by the platform teams

See [blogpost](https://confluence.tools.tax.service.gov.uk/display/TEC/2020/12/01/Cleanup+deprecated+Play+framework+configuration+keys)